### PR TITLE
Force Mixed Content on HTTP and Xhr/Fetch API requests that contain CSP headers

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -151,7 +151,7 @@ chrome.storage.local.get(storedState => {
     onHeadersReceivedListener,
     {
       urls: ['<all_urls>'],
-      types: ['main_frame', 'sub_frame']
+      types: ['main_frame', 'sub_frame', 'xmlhttprequest']
     },
     ['blocking', 'responseHeaders']
   )

--- a/src/background.js
+++ b/src/background.js
@@ -91,6 +91,12 @@ chrome.storage.local.get(storedState => {
         ) {
           return { redirectUrl }
         }
+      }).catch(error => {
+          console.error(error)
+          if(error.response.status === 405)//HEAD method not allowed
+          {
+              return { redirectUrl }
+          }
       })
     }
   }
@@ -135,7 +141,7 @@ chrome.storage.local.get(storedState => {
     onBeforeRequestListener,
     {
       urls: ['<all_urls>'],
-      types: ['image']
+      types: isFirefox() ? ['imageset', 'image'] : ['image']
     },
     ['blocking']
   )
@@ -143,7 +149,7 @@ chrome.storage.local.get(storedState => {
     onCompletedListener,
     {
       urls: ['<all_urls>'],
-      types: ['image']
+      types: isFirefox() ? ['imageset', 'image'] : ['image']
     },
     ['responseHeaders']
   )

--- a/src/background.js
+++ b/src/background.js
@@ -58,12 +58,12 @@ chrome.storage.local.get(storedState => {
   /**
    * Intercept image loading request and decide if we need to compress it.
    */
-  function onBeforeRequestListener({ url }) {
+  function onBeforeRequestListener({ url, documentUrl }) {
     checkSetup()
     if (
       shouldCompress({
         imageUrl: url,
-        pageUrl,
+        pageUrl: pageUrl || parseUrl(documentUrl).host, //occasionally pageUrl is not ready in time on FF
         compressed,
         proxyUrl: state.proxyUrl,
         disabledHosts: state.disabledHosts,
@@ -92,7 +92,6 @@ chrome.storage.local.get(storedState => {
           return { redirectUrl }
         }
       }).catch(error => {
-          console.error(error)
           if(error.response.status === 405)//HEAD method not allowed
           {
               return { redirectUrl }

--- a/src/background/patchContentSecurity.js
+++ b/src/background/patchContentSecurity.js
@@ -1,9 +1,24 @@
 export default (headers, proxyUrl) =>
-  headers.map(header => {
+{ 
+proxyUrl = new URL(proxyUrl) || proxyUrl;
+let proxyHost = proxyUrl.protocol + "//" + proxyUrl.host;
+let isHttp = proxyUrl.protocol === "http:";
+    
+return headers.map(header => {
     return /content-security-policy/i.test(header.name)
       ? {
           name: header.name,
-          value: header.value.replace('img-src', `img-src ${proxyUrl}`)
+          value: stripMixedContentCSP(header.value, isHttp)
+            .replace('img-src', `img-src ${proxyHost}`)
+            .replace('default-src', `default-src ${proxyHost}`)
+            .replace('connect-src', `connect-src ${proxyHost}`)
         }
       : header
   })
+}
+
+function stripMixedContentCSP (CSPHeader, isHttp) {
+    return isHttp ? 
+        CSPHeader.replace('block-all-mixed-content', '') : 
+        CSPHeader;
+}

--- a/src/background/patchContentSecurity.test.js
+++ b/src/background/patchContentSecurity.test.js
@@ -8,7 +8,7 @@ it('should return new headers array with patched header', () => {
     },
     {
       name: 'Content-Security-Policy',
-      value: 'img-src https://google.com;'
+      value: 'img-src https://google.com; block-all-mixed-content'
     }
   ]
   const proxyUrl = 'https://webtask.io/bandwidth-hero'
@@ -19,7 +19,7 @@ it('should return new headers array with patched header', () => {
     },
     {
       name: 'Content-Security-Policy',
-      value: 'img-src https://webtask.io/bandwidth-hero https://google.com;'
+      value: 'img-src https://webtask.io https://google.com;'
     }
   ]
 

--- a/src/background/patchContentSecurity.test.js
+++ b/src/background/patchContentSecurity.test.js
@@ -8,7 +8,7 @@ it('should return new headers array with patched header', () => {
     },
     {
       name: 'Content-Security-Policy',
-      value: 'img-src https://google.com; block-all-mixed-content'
+      value: "default-src 'none'; img-src https://google.com; block-all-mixed-content;"
     }
   ]
   const proxyUrl = 'https://webtask.io/bandwidth-hero'
@@ -19,7 +19,27 @@ it('should return new headers array with patched header', () => {
     },
     {
       name: 'Content-Security-Policy',
-      value: 'img-src https://webtask.io https://google.com;'
+      value: "default-src https://webtask.io 'none'; img-src https://webtask.io https://google.com; block-all-mixed-content;"
+    }
+  ]
+
+  expect(patchContentSecurity(originalHeaders, proxyUrl)).toEqual(
+    expectedHeaders
+  )
+})
+
+it('should strip out "block-all-mixed-content" CSP flag, if the proxyUrl protocol is http:', () => {
+    const originalHeaders = [
+    {
+      name: 'Content-Security-Policy',
+      value: "default-src 'none'; img-src https://google.com; block-all-mixed-content; connect-src foobar.baz"
+    }
+  ]
+  const proxyUrl = 'http://webtask.io/bandwidth-hero'
+  const expectedHeaders = [
+    {
+      name: 'Content-Security-Policy',
+      value: "default-src http://webtask.io 'none'; img-src http://webtask.io https://google.com; ; connect-src http://webtask.io foobar.baz"
     }
   ]
 

--- a/src/background/shouldCompress.js
+++ b/src/background/shouldCompress.js
@@ -2,7 +2,7 @@ import { Netmask } from 'netmask'
 
 export default ({ imageUrl, pageUrl, compressed, proxyUrl, disabledHosts, enabled }) => {
   imageUrl = imageUrl.replace('#bh-no-compress=1', '')
-  const skip = [proxyUrl, 'favicon', '.*.ico', '.*.svg'].concat(disabledHosts)
+  const skip = [proxyUrl, 'favicon', '.*\\.ico', '.*\\.svg'].concat(disabledHosts)
   const skipRegExp = new RegExp(`(${skip.join('|')})`, 'i')
 
   return (

--- a/src/background/shouldCompress.test.js
+++ b/src/background/shouldCompress.test.js
@@ -305,3 +305,28 @@ it('should not compress tracking pixels', () => {
     })
   ).toBeFalsy()
 })
+
+it('Should have a regexp with the file extension properly escaped', () => {
+  expect(
+    shouldCompress({
+      imageUrl: 'https://siliconera.com',
+      disabledHosts: [],
+      pageUrl: 'siliconera.com',
+      compressed: new Set(),
+      proxyUrl: 'https://webtask.io/bandwidth-hero',
+      enabled: true
+    })
+  ).toBeTruthy()
+  
+  expect(
+    shouldCompress({
+      imageUrl: 'https://whoasvgomg.com',
+      disabledHosts: [],
+      pageUrl: 'siliconera.com',
+      compressed: new Set(),
+      proxyUrl: 'https://webtask.io/bandwidth-hero',
+      enabled: true
+    })
+  ).toBeTruthy()
+})
+

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "name": "Bandwidth Hero - Live Image Compression",
   "short_name": "Bandwidth Hero",
   "description": "Saves data by compressing images on the page.",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "icons": {
     "64": "assets/icon-128.png",
     "128": "assets/icon-256.png"


### PR DESCRIPTION
Fixes https://github.com/ayastreb/bandwidth-hero-proxy/issues/16 (tested on github.com) and #20 
(tested on mobile.twitter.com). I've tested on web-ext on both Android and Desktop.

**Force Mixed Content:** Fixes https://github.com/ayastreb/bandwidth-hero-proxy/issues/16
Could be further optimized by storing the protocol information or whether or not it's http vs https/SSL in the state. (the solution here's not the most elegant).

**Fetch API requests that contain CSP headers** Fixes #20
the onHeadersReceived listener is now also happening to xmlhttprequest however, it really only seems necessary because mobile.twitter.com on firefox for android uses the fetch api (on desktop it uses xhr). Here the fetch requests provide have their own CSP headers when re-enforce the CSP policies after they're brought in. This could also affect other PWAs that utilize the Fetch API and set (forget to unset?) CSP on those headers, however the performance impact could be mitigated by detecting and filtering so that the onHeadersReceived handler only acts on Fetch API and not Xhr (although Xhr could possibly be affected if it had CSP policies set on its headers).

**Added proxy to default-src and connect-src for some reason**
I didn't take these out because they might be good fallback measures, but yes they also punch more holes through CSP security...