### PR TITLE
Display correct extension in compression settings

### DIFF
--- a/src/components/CompressionSettings.js
+++ b/src/components/CompressionSettings.js
@@ -2,12 +2,16 @@ import React from 'react'
 import { Form, Input, Checkbox, Dropdown, Button } from 'semantic-ui-react'
 import defaults from '../defaults'
 
-export default ({ convertBw, compressionLevel, onConvertBwChange, onCompressionLevelChange }) => {
+export default ({ convertBw, compressionLevel, onConvertBwChange, onCompressionLevelChange, isWebpSupported }) => {
+  const compressionToText = (description, value) => {
+    const extension = isWebpSupported ? 'WEBP' : 'JPG';
+    return `${description} compression (${extension} ${value})`;
+  };
   const compressionLevelOptions = [
-    { key: 80, value: 80, text: 'Low compression (JPG 80)' },
-    { key: 60, value: 60, text: 'Medium compression (JPG 60)' },
-    { key: 40, value: 40, text: 'High compression (JPG 40)' },
-    { key: 20, value: 20, text: 'Extreme compression (JPG 20)' }
+    { key: 80, value: 80, text: compressionToText('Low', 80) },
+    { key: 60, value: 60, text: compressionToText('Medium', 60) },
+    { key: 40, value: 40, text: compressionToText('High', 40) },
+    { key: 20, value: 20, text: compressionToText('Extreme', 20) }
   ]
   return (
     <div>

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -13,6 +13,7 @@ export default ({
   onSiteEnable,
   disabledOnChange,
   convertBwOnChange,
+  isWebpSupported,
   compressionLevelOnChange
 }) => (
   <div>
@@ -30,6 +31,7 @@ export default ({
     <SettingsAccordion
       disabledHosts={disabledHosts}
       convertBw={convertBw}
+      isWebpSupported={isWebpSupported}
       compressionLevel={compressionLevel}
       disabledOnChange={disabledOnChange}
       convertBwOnChange={convertBwOnChange}

--- a/src/components/SettingsAccordion.js
+++ b/src/components/SettingsAccordion.js
@@ -9,6 +9,7 @@ export default ({
   compressionLevel,
   disabledOnChange,
   convertBwOnChange,
+  isWebpSupported,
   compressionLevelOnChange
 }) => {
   return (
@@ -28,6 +29,7 @@ export default ({
         <Accordion.Content>
           <CompressionSettings
             convertBw={convertBw}
+            isWebpSupported={isWebpSupported}
             compressionLevel={compressionLevel}
             onConvertBwChange={convertBwOnChange}
             onCompressionLevelChange={compressionLevelOnChange}

--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -15,6 +15,7 @@ export default class Popup extends React.Component {
       disabledHosts: props.disabledHosts,
       convertBw: props.convertBw,
       compressionLevel: props.compressionLevel,
+      isWebpSupported: props.isWebpSupported,
       proxyUrl: props.proxyUrl
     }
     if(!chrome.storage.onChanged.hasListener(this.stateWasUpdatedFromBackground)){
@@ -72,7 +73,7 @@ export default class Popup extends React.Component {
   }
 
   compressionLevelWasChanged = (_, { value }) => {
-    this.setState(() => { 
+    this.setState(() => {
         let compressionLvl = {compressionLevel: value }
         chrome.storage.local.set(compressionLvl)
         return compressionLvl


### PR DESCRIPTION
The popup showed JPG even if it supported WEBP. This commit passes the
WEBP test along and displays the correct extension.

Also, my editor found some trailing whitespace and fixed those along with wrong indentation in `onBeforeRequestListener`.

![Screenshot 2019-08-08 at 09 23 38](https://user-images.githubusercontent.com/1044316/62683351-7aff7e80-b9be-11e9-8758-d68db5744ba6.png)
