### PR TITLE
Do not count to processed files when from cache

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -137,10 +137,10 @@ chrome.storage.local.get(storedState => {
      * Retrieve saved bytes info from response headers, update statistics in
      * app storage and notify UI about state changes.
      */
-    function onCompletedListener({ responseHeaders }) {
+    function onCompletedListener({ responseHeaders, fromCache }) {
         const bytesSaved = getHeaderValue(responseHeaders, 'x-bytes-saved')
         const bytesProcessed = getHeaderValue(responseHeaders, 'x-original-size')
-        if (bytesSaved !== false && bytesProcessed !== false) {
+        if (bytesSaved !== false && bytesProcessed !== false && fromCache === false) {
             state.statistics.filesProcessed += 1
             state.statistics.bytesProcessed += bytesProcessed
             state.statistics.bytesSaved += bytesSaved


### PR DESCRIPTION
The extension always adds files even when the files are read from disk (cached in the browser). This gives skewed statistics. Luckily for us, Chrome gives us `fromCache` which is a boolean attribute. I've added the check to prevent adding to statistics when the file is read from cache.