### PR TITLE
Fix Firefox not catching images by xmlhttprequest.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4299,7 +4299,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4320,12 +4321,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4340,17 +4343,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4467,7 +4473,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4479,6 +4486,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4493,6 +4501,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4500,12 +4509,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4524,6 +4535,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4604,7 +4616,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4616,6 +4629,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4701,7 +4715,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4737,6 +4752,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4756,6 +4772,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4799,12 +4816,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5346,6 +5365,11 @@
       "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
       "dev": true
     },
+    "image-extensions": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/image-extensions/-/image-extensions-1.1.0.tgz",
+      "integrity": "sha1-uOa/YDnfAFbjM1AqALZjejEF2JQ="
+    },
     "img-loader": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/img-loader/-/img-loader-3.0.1.tgz",
@@ -5609,6 +5633,14 @@
       "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
+      }
+    },
+    "is-image": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-image/-/is-image-3.0.0.tgz",
+      "integrity": "sha512-NNPLvwKZ/hqx1Wv+ayKvVeDOylIapVKSxK/guzmB9doAk0FEdK0KqFKbnwNbuMLEPqEY4NaBhxzB4e98fVOq2Q==",
+      "requires": {
+        "image-extensions": "^1.1.0"
       }
     },
     "is-number": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@babel/runtime": "^7.3.4",
     "axios": "^0.18.0",
+    "is-image": "^3.0.0",
     "netmask": "^1.0.6",
     "pretty-bytes": "^4.0.2",
     "react": "^16.8.4",

--- a/src/background.js
+++ b/src/background.js
@@ -83,7 +83,7 @@ chrome.storage.local.get(storedState => {
     /**
      * Intercept image loading request and decide if we need to compress it.
      */
-    function onBeforeRequestListener({ url, documentUrl }) {
+    function onBeforeRequestListener({ url, documentUrl, type }) {
         checkSetup()
         if (
             shouldCompress({
@@ -92,7 +92,8 @@ chrome.storage.local.get(storedState => {
                     compressed,
                     proxyUrl: state.proxyUrl,
                     disabledHosts: state.disabledHosts,
-                    enabled: state.enabled
+                    enabled: state.enabled,
+                    type
             })
         ) {
             compressed.add(url)
@@ -176,7 +177,7 @@ chrome.storage.local.get(storedState => {
                 onBeforeRequestListener,
                 {
                     urls: ['<all_urls>'],
-                    types: isFirefox() ? ['imageset', 'image'] : ['image']
+                    types: isFirefox() ? ['xmlhttprequest', 'imageset', 'image'] : ['image']
                 },
                 ['blocking']
             )
@@ -186,7 +187,7 @@ chrome.storage.local.get(storedState => {
                 onCompletedListener,
                 {
                     urls: ['<all_urls>'],
-                    types: isFirefox() ? ['imageset', 'image'] : ['image']
+                    types: isFirefox() ? ['xmlhttprequest', 'imageset', 'image'] : ['image']
                 },
                 ['responseHeaders']
             )

--- a/src/background/shouldCompress.js
+++ b/src/background/shouldCompress.js
@@ -1,6 +1,7 @@
 import { Netmask } from 'netmask'
+import isImage from 'is-image';
 
-export default ({ imageUrl, pageUrl, compressed, proxyUrl, disabledHosts, enabled }) => {
+export default ({ imageUrl, pageUrl, compressed, proxyUrl, disabledHosts, enabled, type }) => {
   imageUrl = imageUrl.replace('#bh-no-compress=1', '')
   const skip = [proxyUrl, 'favicon', '.*\\.ico', '.*\\.svg'].concat(disabledHosts)
   const skipRegExp = new RegExp(`(${skip.join('|')})`, 'i')
@@ -14,7 +15,8 @@ export default ({ imageUrl, pageUrl, compressed, proxyUrl, disabledHosts, enable
     !isPrivateNetwork(imageUrl) &&
     !isTracking(imageUrl) &&
     !disabledHosts.includes(pageUrl) &&
-    !skipRegExp.test(imageUrl)
+    !skipRegExp.test(imageUrl) &&
+    isImageUrl(imageUrl, type)
   )
 }
 
@@ -56,4 +58,16 @@ function isTracking(url) {
   }
 
   return false
+}
+
+function isImageUrl(imageUrl, type) {
+  if (type.toLowerCase() !== "xmlhttprequest") {
+    return true;
+  }
+  const url = stripQueryStringAndHashFromPath(imageUrl)
+  return isImage(url);
+}
+
+function stripQueryStringAndHashFromPath(url) {
+  return url.split("?")[0].split("#")[0];
 }

--- a/src/background/shouldCompress.test.js
+++ b/src/background/shouldCompress.test.js
@@ -309,7 +309,7 @@ it('should not compress tracking pixels', () => {
 it('Should have a regexp with the file extension properly escaped', () => {
   expect(
     shouldCompress({
-      imageUrl: 'https://siliconera.com',
+      imageUrl: 'https://siliconera.com/example.png',
       disabledHosts: [],
       pageUrl: 'siliconera.com',
       compressed: new Set(),
@@ -320,7 +320,7 @@ it('Should have a regexp with the file extension properly escaped', () => {
   
   expect(
     shouldCompress({
-      imageUrl: 'https://whoasvgomg.com',
+      imageUrl: 'https://whoasvgomg.com/example.png',
       disabledHosts: [],
       pageUrl: 'siliconera.com',
       compressed: new Set(),


### PR DESCRIPTION
In Firefox images that are loaded through XMLHttpRequest/Fetch are not
part of the "image" or "imageset" filter for WebRequest. Instead they
are labeld as "xmlhttprequest". To catch them we add the
"xmlhttprequest" to the filter and explicit check if the url is an
image. An example where this occurs is on a Discourse forum.