### PR TITLE
Improvements catching images

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -265,8 +265,8 @@ chrome.storage.local.get(storedState => {
         chrome.tabs.onUpdated.addListener(onTabUpdated)
     }
 
-    if (!chrome.storage.onChanged.hasListener(onChanged)) {
-        chrome.storage.onChanged.addListener(onChanged)
+    if (!chrome.storage.onChanged.hasListener(onStateChanged)) {
+        chrome.storage.onChanged.addListener(onStateChanged)
     }
 
     if (!chrome.runtime.onInstalled.hasListener(onInstalled)) {

--- a/src/background.js
+++ b/src/background.js
@@ -5,107 +5,112 @@ import parseUrl from './utils/parseUrl'
 import deferredStateStorage from './utils/deferredStateStorage'
 import defaultState from './defaults'
 import axios from 'axios'
+import isPrivateNetwork from './background/isPrivateNetwork';
 
 chrome.storage.local.get(storedState => {
     const storage = deferredStateStorage()
     const compressed = new Set();
-    let setupOpen
-    let state
-    let pageUrl
-    let isWebpSupported
+    let setupHasBeenOpened = false;
+    let state = { ...defaultState, ...storedState };
+    let currentPageUrl = null;
+    let currentPageProtocol = null;
 
     if (/compressor\.bandwidth-hero\.com/i.test(storedState.proxyUrl)) {
         chrome.storage.local.set({ ...storedState, proxyUrl: '' })
     }
 
-    setState({ ...defaultState, ...storedState })
-
     checkWebpSupport().then(isSupported => {
-        isWebpSupported = isSupported
         chrome.storage.local.set({ ...storedState, isWebpSupported: isSupported })
     })
 
     async function checkWebpSupport() {
         if (!self.createImageBitmap) return false
-
-            const webpData = 'data:image/webp;base64,UklGRh4AAABXRUJQVlA4TBEAAAAvAAAAAAfQ//73v/+BiOh/AAA='
-            const blob = await fetch(webpData).then(r => r.blob())
-            return self.createImageBitmap(blob).then(() => true, () => false)
-    }
-
-    /**
-     * Sync state.
-     */
-    function setState(newState) {
-        if (!state || state.enabled !== newState.enabled) {
-            setIcon(newState.enabled);
-        }
-        state = newState
-        //attach or remove listeners based on state.enabled
-        state.enabled ? attachListeners() : detachListeners()
-        return true //acknowledge
+        const webpData = 'data:image/webp;base64,UklGRh4AAABXRUJQVlA4TBEAAAAvAAAAAAfQ//73v/+BiOh/AAA='
+        const blob = await fetch(webpData).then(r => r.blob())
+        return self.createImageBitmap(blob).then(() => true, () => false)
     }
 
     /**
      * Sets the icons based on the disabled parameter.
-     * @param enabled
      */
-    function setIcon(enabled) {
+    function setIcon() {
+        const isEnabled = state.enabled && !isDisabledSite();
         if (chrome.browserAction.setIcon) {
             chrome.browserAction.setIcon({
-                path: enabled ? 'assets/icon-128.png' : 'assets/icon-128-disabled.png'
-            })
+                path: isEnabled ? "assets/icon-128.png" : "assets/icon-128-disabled.png"
+            });
         }
     }
 
     /**
      * Checks if the proxy is disabled for the given url
-     * @param url
      * @returns {boolean}
      */
-    function isDisabledSite(url) {
-        const disabledHosts = state && state.disabledHosts || []
-        return disabledHosts.includes(url)
+    function isDisabledSite() {
+        // If we don't have the URL or protocol we can't check if it is enabled.
+        if (!currentPageUrl || !currentPageProtocol) {
+            return true;
+        }
+
+        // Check if the page is a http/https page.
+        const supportedProtocols = ['http:', 'https:'];
+        if (!supportedProtocols.includes(currentPageProtocol)) {
+            return true;
+        }
+
+        // We are disabled when on localhost or site is hosted on private IP.
+        if (isPrivateNetwork(currentPageUrl)) {
+            return true;
+        }
+        return state.disabledHosts.includes(currentPageUrl);
     }
 
     /**
-     * refreshState
+     * Every time the storage of the browser changes we also update our in-memory state to keep up with the changes.
+     *
      */
-    function updateState(changes) {
-        const changedItems = Object.keys(changes)
+    function onStateChanged(changes) {
+        const changedItems = Object.keys(changes);
         for (const item of changedItems) {
-            if( state[item] !== changes[item].newValue){
-                state[item] = changes[item].newValue
-                if(item === "enabled"){
-                    state.enabled ? attachListeners() : detachListeners()
-                    setIcon(state.enabled);
-                } else if (item === "disabledHosts") {
-                    const disabled = isDisabledSite(pageUrl)
-                    setIcon(!disabled);
-                }
+            if (state[item] !== changes[item].newValue) {
+                state[item] = changes[item].newValue;
+                stateItemChanged(item, state[item]);
             }
+        }
+    }
+
+    /**
+     * Perform actions for certain changes to the state. Like changing the icon if we enable/disable the extension.
+     * @param key
+     * @param newValue
+     */
+    function stateItemChanged(key, newValue) {
+        switch (key) {
+            case 'enabled':
+            case 'disabledHosts':
+                setIcon(); // Update icon
+                break;
         }
     }
 
     function checkSetup() {
-        if(state.enabled){
-            attachListeners()
-            if (
-                !setupOpen &&
-                (state.proxyUrl === '' || /compressor\.bandwidth-hero\.com/i.test(state.proxyUrl))
-            ) {
-                chrome.tabs.create({ url: 'setup.html' })
-                setupOpen = true
-
-            }
+        if (!state.enabled) return;
+        if (setupHasBeenOpened) return;
+        if (state.proxyUrl === '' || /compressor\.bandwidth-hero\.com/i.test(state.proxyUrl)) {
+            chrome.tabs.create({ url: 'setup.html' });
+            setupHasBeenOpened = true;
         }
+    }
+
+    function onInstalled() {
+        checkSetup();
     }
 
     /**
      * Intercept image loading request and decide if we need to compress it.
      */
     function onBeforeRequestListener({ url, documentUrl, type }) {
-        checkSetup()
+        checkSetup();
 
         // Occasionally currentPageUrl is not ready in time on FF
         const pageUrl = currentPageUrl || parseUrl(documentUrl).host;
@@ -180,9 +185,10 @@ chrome.storage.local.get(storedState => {
      * app storage and notify UI about state changes.
      */
     function onCompletedListener({ responseHeaders, fromCache }) {
+        if (fromCache) return;
         const bytesSaved = getHeaderValue(responseHeaders, 'x-bytes-saved')
         const bytesProcessed = getHeaderValue(responseHeaders, 'x-original-size')
-        if (bytesSaved !== false && bytesProcessed !== false && fromCache === false) {
+        if (bytesSaved !== false && bytesProcessed !== false) {
             state.statistics.filesProcessed += 1
             state.statistics.bytesProcessed += bytesProcessed
             state.statistics.bytesSaved += bytesSaved
@@ -191,19 +197,20 @@ chrome.storage.local.get(storedState => {
         }
     }
 
-    function tabActivationListener({tabId}) {
+    function onTabActivated({tabId}) {
         chrome.tabs.get(tabId, tab => {
-            pageUrl = parseUrl(tab.url).hostname;
-            const disabled = isDisabledSite(pageUrl)
-            setIcon(!disabled)
+            const url = parseUrl(tab.url);
+            currentPageUrl = url.hostname;
+            currentPageProtocol = url.schema;
             compressed.clear(); // Reset our list of compressed images
+            setIcon();
         });
     }
 
     // If we navigate to a new page within a tab and it is the same we have a
     // bug where it does not process images. Because the images are still in
     // compressed even though the page changed. With onTabUpdated we reset this.
-    function tabUpdateListener(){
+    function onTabUpdated(){
       compressed.clear()
     }
 
@@ -216,57 +223,53 @@ chrome.storage.local.get(storedState => {
             responseHeaders: patchContentSecurity(responseHeaders, state.proxyUrl)
         }
     }
-    function attachListeners(){
-        if(!chrome.webRequest.onBeforeRequest.hasListener(onBeforeRequestListener)){
-            chrome.webRequest.onBeforeRequest.addListener(
-                onBeforeRequestListener,
-                {
-                    urls: ['<all_urls>'],
-                    types: isFirefox() ? ['xmlhttprequest', 'imageset', 'image'] : ['image']
-                },
-                ['blocking']
-            )
-        }
-        if(!chrome.webRequest.onCompleted.hasListener(onCompletedListener)){
-            chrome.webRequest.onCompleted.addListener(
-                onCompletedListener,
-                {
-                    urls: ['<all_urls>'],
-                    types: isFirefox() ? ['xmlhttprequest', 'imageset', 'image'] : ['image']
-                },
-                ['responseHeaders']
-            )
-        }
-        if(!chrome.webRequest.onHeadersReceived.hasListener(onHeadersReceivedListener)){
-            chrome.webRequest.onHeadersReceived.addListener(
-                onHeadersReceivedListener,
-                {
-                    urls: ['<all_urls>'],
-                    types: ['main_frame', 'sub_frame', 'xmlhttprequest']
-                },
-                ['blocking', 'responseHeaders']
-            )
-        }
-        if(!chrome.tabs.onActivated.hasListener(tabActivationListener)){
-            chrome.tabs.onActivated.addListener(tabActivationListener)
-        }
-        if(!chrome.tabs.onUpdated.hasListener(tabUpdateListener)){
-            chrome.tabs.onUpdated.addListener(tabUpdateListener)
-        }
+
+    if (!chrome.webRequest.onBeforeRequest.hasListener(onBeforeRequestListener)) {
+        chrome.webRequest.onBeforeRequest.addListener(
+            onBeforeRequestListener,
+            {
+                urls: ['<all_urls>'],
+                types: isFirefox() ? ['xmlhttprequest', 'imageset', 'image'] : ['image']
+            },
+            ['blocking']
+        )
     }
 
-    function detachListeners(){
-        chrome.webRequest.onBeforeRequest.removeListener(onBeforeRequestListener)
-        chrome.webRequest.onCompleted.removeListener(onCompletedListener)
-        chrome.webRequest.onHeadersReceived.removeListener(onHeadersReceivedListener)
-        chrome.tabs.onActivated.removeListener(tabActivationListener)
-        chrome.tabs.onUpdated.removeListener(tabUpdateListener)
+    if (!chrome.webRequest.onCompleted.hasListener(onCompletedListener)) {
+        chrome.webRequest.onCompleted.addListener(
+            onCompletedListener,
+            {
+                urls: ['<all_urls>'],
+                types: isFirefox() ? ['xmlhttprequest', 'imageset', 'image'] : ['image']
+            },
+            ['responseHeaders']
+        )
     }
 
-    if(!chrome.storage.onChanged.hasListener(updateState)){
-        chrome.storage.onChanged.addListener(updateState)
+    if (!chrome.webRequest.onHeadersReceived.hasListener(onHeadersReceivedListener)) {
+        chrome.webRequest.onHeadersReceived.addListener(
+            onHeadersReceivedListener,
+            {
+                urls: ['<all_urls>'],
+                types: ['main_frame', 'sub_frame', 'xmlhttprequest']
+            },
+            ['blocking', 'responseHeaders']
+        )
     }
-    if(!chrome.runtime.onInstalled.hasListener(checkSetup)){
-        chrome.runtime.onInstalled.addListener(checkSetup)
+
+    if (!chrome.tabs.onActivated.hasListener(onTabActivated)) {
+        chrome.tabs.onActivated.addListener(onTabActivated)
+    }
+
+    if (!chrome.tabs.onUpdated.hasListener(onTabUpdated)) {
+        chrome.tabs.onUpdated.addListener(onTabUpdated)
+    }
+
+    if (!chrome.storage.onChanged.hasListener(onChanged)) {
+        chrome.storage.onChanged.addListener(onChanged)
+    }
+
+    if (!chrome.runtime.onInstalled.hasListener(onInstalled)) {
+        chrome.runtime.onInstalled.addListener(onInstalled)
     }
 })

--- a/src/background/isPrivateNetwork.js
+++ b/src/background/isPrivateNetwork.js
@@ -1,0 +1,25 @@
+import { Netmask } from 'netmask'
+
+/**
+ * Check if an URL is localhost or part of a private IP. If it is private we
+ * can't reach it with our proxy. So we should skip compressing those URLs.
+ */
+export default (url) => {
+  if (url === 'localhost' || /^https?:\/\/(localhost|127.0.0.1).*/i.test(url)) {
+    return true;
+  }
+
+  const ipAddress = url.match(/^https?:\/\/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}).*/)
+  if (ipAddress) {
+    const privateBlocks = [
+      new Netmask('10.0.0.0/8'),
+      new Netmask('172.16.0.0/12'),
+      new Netmask('192.168.0.0/16')
+    ]
+    for (const block of privateBlocks) {
+      if (block.contains(ipAddress[1])) return true
+    }
+  }
+
+  return false
+}

--- a/src/background/shouldCompress.js
+++ b/src/background/shouldCompress.js
@@ -1,46 +1,99 @@
-import { Netmask } from 'netmask'
 import isImage from 'is-image';
+import isPrivateNetwork from './isPrivateNetwork';
+import parseUrl from '../utils/parseUrl';
 
 export default ({ imageUrl, pageUrl, compressed, proxyUrl, disabledHosts, enabled, type = 'image' }) => {
-  imageUrl = imageUrl.replace('#bh-no-compress=1', '')
-  const skip = [proxyUrl, 'favicon', '.*\\.ico', '.*\\.svg'].concat(disabledHosts)
-  const skipRegExp = new RegExp(`(${skip.join('|')})`, 'i')
+  imageUrl = imageUrl.replace('#bh-no-compress=1', '');
 
-  return (
-    enabled &&
-    proxyUrl !== '' &&
-    !/compressor\.bandwidth-hero\.com/i.test(proxyUrl) &&
-    /https?:\/\/.+/i.test(imageUrl) &&
-    !compressed.has(imageUrl) &&
-    !isPrivateNetwork(imageUrl) &&
-    !isTracking(imageUrl) &&
-    !disabledHosts.includes(pageUrl) &&
-    !skipRegExp.test(imageUrl) &&
-    isImageUrl(imageUrl, type)
-  )
-}
-
-function isPrivateNetwork(url) {
-  if (/^https?:\/\/(localhost|127.0.0.1).*/i.test(url)) return true
-  const ipAddress = url.match(/^https?:\/\/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}).*/)
-  if (ipAddress) {
-    const privateBlocks = [
-      new Netmask('10.0.0.0/8'),
-      new Netmask('172.16.0.0/12'),
-      new Netmask('192.168.0.0/16')
-    ]
-    for (const block of privateBlocks) {
-      if (block.contains(ipAddress[1])) return true
-    }
+  // If we aren't enabled we don't have to do anything.
+  if (!enabled) {
+    return false;
   }
 
-  return false
-}
+  // If we don't have an proxy URL we can't compress.
+  if (proxyUrl === '') {
+    return false;
+  }
 
-function isTracking(url) {
+  // Do not compress using the legacy proxy service. This proxy was default in
+  // earlier versions of the extension and filled in by default. So for legacy
+  // reasons we need to check for this.
+  if (/compressor\.bandwidth-hero\.com/i.test(proxyUrl)) {
+    return false;
+  }
+
+  // We keep a list of compressed images to prevent infinite loops. If the proxy
+  // can't process an image and redirects the browser to the original it will come
+  // back as a normal request. If we don't keep track it will keep looping around
+  // sending the image to the proxy and proxy redirecting.
+  if (compressed.has(imageUrl)) {
+    return false;
+  }
+
+  // Only process http or https other protocols including base64 encode URLs are
+  // not supported.
+  const isHttps = imageUrl.toLowerCase().startsWith('https://') ||
+                  imageUrl.toLowerCase().startsWith('http://');
+  if (!isHttps) {
+    return false;
+  }
+
+  // Do not process tracking URLs.
+  if (isTrackingPixel(imageUrl)) {
+    return false;
+  }
+
+  // Clean the image URL and checks if it starts with the proxy URL. Since the
+  // request is our own redirect and shouldn't be processed.
+  const cleanImageUrl = stripQueryStringAndHashFromPath(imageUrl);
+  if (cleanImageUrl.startsWith(proxyUrl)) {
+    return false;
+  }
+
+  // Local images aren't accessible for out proxy.
+  if (isPrivateNetwork(imageUrl)) {
+    return false;
+  }
+
+  // If the host of the page or image is disabled then do nothing.
+  if (disabledHosts.includes(pageUrl)) {
+    return false;
+  }
+
+  // If the host of the page or image is disabled then do nothing.
+  const imageHost = parseUrl(cleanImageUrl).hostname;
+  if (disabledHosts.includes(imageHost)) {
+    return false;
+  }
+
+  // Check if the image doesn't have an extension we can't compress.
+  const notSupported = ['ico', 'svg'];
+  const matched = notSupported.filter(ext => imageUrl.endsWith('.' + ext));
+  if (matched.length > 0) {
+    return false;
+  }
+
+  // Do not process favicons. Those are too small to process most of the time.
+  if (imageUrl.includes('favicon')) {
+    return false;
+  }
+
+  // Firefox will set some images behind a xmlhttprequest instead of
+  // image/imageset. But, listening to xmlhttprequest will also give us other
+  // files like JS of CSS. By checking if the clean URL is an image we make sure
+  // to only get images. But, do this only if the type of the request is
+  // xmlhttprequest.
+  if (type.toLowerCase() === 'xmlhttprequest' && !isImage(cleanImageUrl)) {
+    return false;
+  }
+
+  return true;
+};
+
+function isTrackingPixel(url) {
   const trackingLinks = [
     /pagead/i,
-    /(pixel|px|cleardot)\.*(gif|jpg|jpeg)/i,
+    /(pixel|cleardot)\.*(gif|jpg|jpeg)/i,
     /google\.([a-z\.]+)\/(ads|generate_204|.*\/log204)+/i,
     /google-analytics\.([a-z\.]+)\/(r|collect)+/i,
     /youtube\.([a-z\.]+)\/(api|ptracking|player_204|live_204)+/i,
@@ -50,24 +103,18 @@ function isTracking(url) {
     /facebook\.([a-z\.]+)\/(impression\.php|tr)+/i,
     /ad\.bitmedia\.io/i,
     /yahoo\.([a-z\.]+)\/pixel/i,
-    /criteo\.net\/img/i
-  ]
+    /criteo\.net\/img/i,
+    /ad\.doubleclick\.net/i
+  ];
 
   for (const link of trackingLinks) {
-    if (link.test(url)) return true
+    if (link.test(url)) {
+      return true;
+    }
   }
-
-  return false
-}
-
-function isImageUrl(imageUrl, type) {
-  if (type.toLowerCase() !== "xmlhttprequest") {
-    return true;
-  }
-  const url = stripQueryStringAndHashFromPath(imageUrl)
-  return isImage(url);
+  return false;
 }
 
 function stripQueryStringAndHashFromPath(url) {
-  return url.split("?")[0].split("#")[0];
+  return url.split('?')[0].split('#')[0];
 }

--- a/src/background/shouldCompress.test.js
+++ b/src/background/shouldCompress.test.js
@@ -13,6 +13,19 @@ it('should not compress when app is disabled', () => {
   ).toBeFalsy()
 })
 
+it('should not compress when there is no proxy set', () => {
+  expect(
+    shouldCompress({
+      imageUrl: 'https://google.com/logo.png',
+      pageUrl: 'https://google.com',
+      compressed: new Set(),
+      proxyUrl: '',
+      disabledHosts: [],
+      enabled: true
+    })
+  ).toBeFalsy()
+})
+
 it('should only compress http or https schema URLs', () => {
   expect(
     shouldCompress({
@@ -57,6 +70,39 @@ it('should only compress http or https schema URLs', () => {
       enabled: true
     })
   ).toBeFalsy()
+
+  expect(
+    shouldCompress({
+      imageUrl: 'moz-extension:///logo.png',
+      pageUrl: 'moz-extension:///foo',
+      compressed: new Set(),
+      proxyUrl: 'https://webtask.io/bandwidth-hero',
+      disabledHosts: [],
+      enabled: true
+    })
+  ).toBeFalsy()
+
+  expect(
+    shouldCompress({
+      imageUrl: 'about:config',
+      pageUrl: 'about:config',
+      compressed: new Set(),
+      proxyUrl: 'https://webtask.io/bandwidth-hero',
+      disabledHosts: [],
+      enabled: true
+    })
+  ).toBeFalsy()
+
+  expect(
+    shouldCompress({
+      imageUrl: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP',
+      pageUrl: 'https://google.com',
+      compressed: new Set(),
+      proxyUrl: 'https://webtask.io/bandwidth-hero',
+      disabledHosts: [],
+      enabled: true
+    })
+  ).toBeFalsy()
 })
 
 it('should not compress when img is redirected', () => {
@@ -84,7 +130,7 @@ it('should not compress when img is redirected', () => {
   ).toBeFalsy()
 })
 
-it('should not compress favicons or .svg', () => {
+it('should not compress favicons, .ico, and .svg', () => {
   expect(
     shouldCompress({
       imageUrl: 'http://google.com/favicon.png',
@@ -304,6 +350,17 @@ it('should not compress tracking pixels', () => {
       enabled: true
     })
   ).toBeFalsy()
+
+  expect(
+    shouldCompress({
+      imageUrl: 'https://example.com/logo-200px.jpg',
+      disabledHosts: ['google.com'],
+      pageUrl: 'foo.com',
+      compressed: new Set(),
+      proxyUrl: 'https://webtask.io/bandwidth-hero',
+      enabled: true
+    })
+  ).toBeTruthy()
 })
 
 it('Should have a regexp with the file extension properly escaped', () => {
@@ -330,3 +387,28 @@ it('Should have a regexp with the file extension properly escaped', () => {
   ).toBeTruthy()
 })
 
+it('should not compress image if the request type is XHR and url is not valid', () => {
+  expect(
+    shouldCompress({
+      imageUrl: 'https://whoasvgomg.com/example.png',
+      disabledHosts: [],
+      pageUrl: 'siliconera.com',
+      compressed: new Set(),
+      proxyUrl: 'https://webtask.io/bandwidth-hero',
+      enabled: true,
+      type: 'xmlhttprequest'
+    })
+  ).toBeTruthy()
+
+  expect(
+    shouldCompress({
+      imageUrl: 'https://whoasvgomg.com/example',
+      disabledHosts: [],
+      pageUrl: 'siliconera.com',
+      compressed: new Set(),
+      proxyUrl: 'https://webtask.io/bandwidth-hero',
+      enabled: true,
+      type: 'xmlhttprequest'
+    })
+  ).toBeFalsy()
+});

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -8,5 +8,6 @@ export default {
   disabledHosts: [],
   convertBw: true,
   compressionLevel: 40,
-  proxyUrl: ''
+  proxyUrl: '',
+  isWebpSupported: false,
 }


### PR DESCRIPTION
I've used and tested, for a month, my fork of the extension containing a lot of changes. During this period I tested improvements for the following goals:

1. catch more images with improved checking for cases;
2. better feedback when the extension is enabled/disabled based on the current page;
3. extension working all the time (bug reported in #23);

Also, to better understand the extension, I've added more documentation about cases and why it does some things a certain way.

For point 1 I've improved the `shouldCompress.js` with cases I came across. At the time of writing, I've used my fork for 32 days with the compression level set to 20% and have reached the following statistics: 55,747 images processed and 2.24GB data saved (91%). There is one case not added to this PR that catches more images: some images have a content type of `application/octet-stream` (example page: https://code.google.com/archive/p/repo-clean/). 

Point 2, was tackled by also checking if the current page is from a private network or has a different protocol (for pages like `about:config` etc.).

Point 3, seems to be resolved. During my 32 days, I've never caught the bug. Before I caught it within two weeks. More testing is needed. The problem, from my debugging a lot, seems to originate from attaching and detaching the listeners. In this PR, I attach the listeners once on startup and keep it that way. It does use a bit more memory and CPU when disabled (since it still listens to images). But, this only minimally since we exit early in the `onBeforeRequest` listener by checking if the extension is enabled. If the extension is disabled/removed by the user, the browser will clean up automatically (tested by adding debug points and disabling/removing the extension).