### PR TITLE
new URL format

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -163,12 +163,14 @@ chrome.storage.local.get(storedState => {
      * @returns {string}
      */
     function buildCompressUrl(url) {
+        const urlMatch = url.match(/^(\w+):\/\/(.*)$/);
         let redirectUrl = '';
         redirectUrl += state.proxyUrl;
-        redirectUrl += `?url=${encodeURIComponent(url)}`;
-        redirectUrl += `&jpeg=${state.isWebpSupported ? 0 : 1}`;
-        redirectUrl += `&bw=${state.convertBw ? 1 : 0}`;
-        redirectUrl += `&l=${state.compressionLevel}`;
+        redirectUrl += urlMatch[1] + "/"; // protocol, mostly "https"
+        redirectUrl += urlMatch[2]; // rest of URL
+        redirectUrl += (state.convertBw ? ".b" : ".c"); // black-white or color
+        redirectUrl += state.compressionLevel;
+        redirectUrl += (state.isWebpSupported ? ".webp" : ".jpg");
         return redirectUrl;
     }
 

--- a/src/background.js
+++ b/src/background.js
@@ -163,14 +163,17 @@ chrome.storage.local.get(storedState => {
      * @returns {string}
      */
     function buildCompressUrl(url) {
-        const urlMatch = url.match(/^(\w+):\/\/(.*)$/);
+        const urlMatch = url.match(/^(\w+):\/\/(.*?)(\?.*)?$/);
         let redirectUrl = '';
         redirectUrl += state.proxyUrl;
         redirectUrl += urlMatch[1] + "/"; // protocol, mostly "https"
-        redirectUrl += urlMatch[2]; // rest of URL
+        redirectUrl += urlMatch[2]; // host + path
         redirectUrl += (state.convertBw ? ".b" : ".c"); // black-white or color
         redirectUrl += state.compressionLevel;
         redirectUrl += (state.isWebpSupported ? ".webp" : ".jpg");
+        if (urlMatch[3]) {
+          redirectUrl += urlMatch[3]; // query string
+        }
         return redirectUrl;
     }
 

--- a/src/background.js
+++ b/src/background.js
@@ -163,16 +163,21 @@ chrome.storage.local.get(storedState => {
      * @returns {string}
      */
     function buildCompressUrl(url) {
-        const urlMatch = url.match(/^(\w+):\/\/(.*?)(\?.*)?$/);
+        const urlMatch = url.match(/^(\w+):\/\/(.*?)(\/+)?(\?.*)?$/);
         let redirectUrl = '';
         redirectUrl += state.proxyUrl;
+        if (urlMatch[3]) {
+          // trailing slashes in path are stripped
+          // add internal query string before protocol
+          redirectUrl += `appendPath=${encodeURIComponent(urlMatch[3])}/`;
+        }
         redirectUrl += urlMatch[1] + "/"; // protocol, mostly "https"
         redirectUrl += urlMatch[2]; // host + path
         redirectUrl += (state.convertBw ? ".b" : ".c"); // black-white or color
         redirectUrl += state.compressionLevel;
         redirectUrl += (state.isWebpSupported ? ".webp" : ".jpg");
-        if (urlMatch[3]) {
-          redirectUrl += urlMatch[3]; // query string
+        if (urlMatch[4]) {
+          redirectUrl += urlMatch[4]; // query string
         }
         return redirectUrl;
     }


### PR DESCRIPTION
old format /?url=https%3A%2F%2Fhost%2Fpath%2Ffile.jpg&jpeg=0&bw=0&l=50
new format /https/host/path/file.jpg.c50.webp
solve issue #22 
new format must be supported by server (bandwidth-hero-proxy)